### PR TITLE
Changed addPokemon resolver behavior to play nicely with bad input

### DIFF
--- a/server/schemas/resolvers.js
+++ b/server/schemas/resolvers.js
@@ -73,7 +73,7 @@ const resolvers = {
         user.teamList.map((team) => {
           if(args.teamName === team.teamName) {
             if(team.pokemonList.length === 6){
-              throw new ValidationError("Pokemon teams may have up to only 6 pokemon");
+              return user.toJSON();
             }
             team.pokemonList.push({pokeName: args.pokeName, dexNumber: args.dexNumber, typeList: args.typeList});
           }


### PR DESCRIPTION
This just lets pokemon be removed from a team even if an attempt to add a pokemon to a full team was made (previously would make all buttons inactive)